### PR TITLE
Perfer local gulp to global gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ This repo provides a polyfill of
 
 The authors need a fast tool to develop polyfill, and thus TypeScript is
 chosen. The end product is still in ES6, located under `dist/` directory
-(You need to call `gulp build` to generate the `dist/` directory).
+(You need to call `npm run gulp build` to generate the `dist/` directory).
 
 ## How to Build It?
 
 ```bash
-npm install -g gulp
 npm install
-gulp
+npm run gulp build
 ```
 
-Supported command line and options will be listed in the gulp command.
+Supported command line and options can be listed using `npm run gulp`.
 
 ## What's the Supported Browser?
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "Polyfill of Relational Database Specification",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's typically recommended to avoid relying on global installs, because that way you can specify the version of `gulp` that is required for building. Since you can pass command-line options to any npm script, my fix is to add a `"gulp"` script that merely calls `"gulp"` (which will use `./node_modules/.bin/gulp` rather than the global one).

I also added `"test": "gulp test"` as a script, since `npm test` is the standard way of invoking tests.